### PR TITLE
TESB416-265 Make database persistent

### DIFF
--- a/data api/src/main/java/de/tinf15b4/kino/api/KinoWebDataService.java
+++ b/data api/src/main/java/de/tinf15b4/kino/api/KinoWebDataService.java
@@ -12,7 +12,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.jsondoc.spring.boot.starter.EnableJSONDoc;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -32,7 +31,6 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 import com.google.gson.Gson;
 
-import de.tinf15b4.kino.data.initializer.DataInitializer;
 import de.tinf15b4.kino.utils.GsonFactory;
 
 @SpringBootApplication
@@ -106,12 +104,14 @@ public class KinoWebDataService extends WebMvcConfigurerAdapter {
         }
     }
 
-    @Bean
-    public CommandLineRunner loadData(DataInitializer initializer) {
-        return (args) -> {
-            initializer.initialize();
-        };
-    }
+    // DON'T enable those lines if you use an existing database. The fake initializer will cause exceptions when writing
+    // to a filled database
+    // @Bean
+    // public CommandLineRunner loadData(DataInitializer initializer) {
+    // return (args) -> {
+    // initializer.initialize();
+    // };
+    // }
 
     @Override
     public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {

--- a/data api/src/main/resources/application.properties
+++ b/data api/src/main/resources/application.properties
@@ -11,3 +11,13 @@ jsondoc.displayMethodAs=URI
 server.port = 9090
 
 spring.http.converters.preferred-json-mapper=gson
+
+#DATABASE
+spring.datasource.driverClassName = org.h2.Driver
+spring.datasource.username = tinf15b4
+spring.datasource.password = smartcinema
+spring.datasource.url = jdbc:h2:file:~/smartCinemaDataBase/smartcinema
+
+# set this line to spring.jpa.hibernate.ddl-auto=create to create a new database
+# if you create a new database, you should enable fake initializer in src/main/java/de/tinf15b4/kino/api/KinoWebDataService.
+spring.jpa.hibernate.ddl-auto = validate

--- a/web app/src/test/java/de/tinf15b4/kino/cucumber/SpringTestConfig.java
+++ b/web app/src/test/java/de/tinf15b4/kino/cucumber/SpringTestConfig.java
@@ -89,7 +89,7 @@ public class SpringTestConfig {
         }
 
         if (!dataApiStarted) {
-            throw new RuntimeException("DEBUG: Temporary data api server did not start on port " + "port");
+            throw new RuntimeException("DEBUG: Temporary data api server did not start on port " + port);
         }
         System.err.println("DEBUG: Started temporary data api server on port " + port);
         startedServerUrl = "http://localhost:" + port;

--- a/web app/src/test/java/de/tinf15b4/kino/cucumber/SpringTestConfig.java
+++ b/web app/src/test/java/de/tinf15b4/kino/cucumber/SpringTestConfig.java
@@ -58,7 +58,9 @@ public class SpringTestConfig {
         pb.redirectInput(ProcessBuilder.Redirect.PIPE);
         pb.environment().put("SMARTCINEMA_DATA_API_LISTEN_ON", "" + port);
         pb.environment().put("SMARTCINEMA_DATA_API_KEEPALIVE_PIPE", "yeah");
-        pb.environment().put("spring.datasource.url", "jdbc:h2:file:~/smartCinemaDataBase/smartcinemaTest");
+
+        //use inmemory
+        pb.environment().put("spring.datasource.url", "");
         pb.environment().put("spring.jpa.hibernate.ddl-auto", "create-drop");
         Process p = pb.start();
 

--- a/web app/src/test/java/de/tinf15b4/kino/cucumber/SpringTestConfig.java
+++ b/web app/src/test/java/de/tinf15b4/kino/cucumber/SpringTestConfig.java
@@ -20,9 +20,13 @@ import de.tinf15b4.kino.web.rest.RestApiUrlSource;
 @TestConfiguration
 public class SpringTestConfig {
     private static String startedServerUrl = null;
+
     private static void startServer() throws Exception {
         if (startedServerUrl != null)
             return;
+
+        System.setProperty("spring.datasource.url", "jdbc:h2:file:~/smartCinemaDataBase/smartcinemaTest");
+        System.setProperty("spring.jpa.hibernate.ddl-auto", "create-drop");
 
         String datadir = System.getenv("SMARTCINEMA_DATA_API_DIR");
         if (datadir == null) {


### PR DESCRIPTION
Database is persistent now. The first time you run the data api you need to manually enable creating the new database by changing some values in application.properties (and for fake data in KinoWebDataService).

Test use their own non-persistent database. This database is created when the tests start and dropped when the application shuts down.